### PR TITLE
Fixed settings screen typo

### DIFF
--- a/src/Settings.bundle/Root.plist
+++ b/src/Settings.bundle/Root.plist
@@ -561,7 +561,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>Streetcat map first</string>
+			<string>Streetcar map first</string>
 			<key>Key</key>
 			<string>streetcar_map_first</string>
 			<key>DefaultValue</key>


### PR DESCRIPTION
Fixed a small typo in the setting screen ("Streetcat" -> "Streetcar")